### PR TITLE
Environ var

### DIFF
--- a/fzf/src/message.go
+++ b/fzf/src/message.go
@@ -20,6 +20,9 @@ func handleMessages(_ *astilectron.Window, m bootstrap.MessageIn) (payload inter
 			astilog.Error(errors.Wrap(err, "json.Unmarshal failed"))
 		}
 		fzfPath := os.Getenv("FZF_PATH")
+		if len(fzfPath) > 0 {
+			fzfPath = fzfPath + "/"
+		}
 		var outputFile, _ = os.Create(fzfPath + ".ColorConfig")
 		defer outputFile.Close()
 		s = s + "\n"

--- a/fzf/src/message.go
+++ b/fzf/src/message.go
@@ -19,7 +19,8 @@ func handleMessages(_ *astilectron.Window, m bootstrap.MessageIn) (payload inter
 		if err := json.Unmarshal(m.Payload, &s); err != nil {
 			astilog.Error(errors.Wrap(err, "json.Unmarshal failed"))
 		}
-		var outputFile, _ = os.Create(".ColorConfig")
+		fzfPath := os.Getenv("FZF_PATH")
+		var outputFile, _ = os.Create(fzfPath + ".ColorConfig")
 		defer outputFile.Close()
 		s = s + "\n"
 		fmt.Fprint(outputFile, s)

--- a/fzf/src/options.go
+++ b/fzf/src/options.go
@@ -1021,19 +1021,7 @@ func parseOptions(opts *Options, allArgs []string) {
 				opts.Theme = tui.EmptyTheme()
 			} else if spec == "g" {
 				initWindow()
-				fzfPath := os.Getenv("FZF_PATH")
-				if len(fzfPath) > 0 {
-					fzfPath = fzfPath + "/"
-				}
-				configFile, err := os.Open(fzfPath + ".ColorConfig")
-				if err == nil {
-					data := make([]byte, 200)
-					configFile.Read(data)
-					words, _ := shellwords.Parse(string(data))
-					if len(words) > 1 {
-						parseOptions(opts, words[:len(words) - 1])
-					}
-				}  
+				ReadColorConfig(opts)  
 			} else {
 				opts.Theme = parseTheme(opts.Theme, spec)
 			}
@@ -1317,6 +1305,18 @@ func ParseOptions() *Options {
 	if len(words) > 0 {
 		parseOptions(opts, words)
 	}
+	
+	ReadColorConfig(opts)
+
+	// Options from command-line arguments
+	parseOptions(opts, os.Args[1:])
+
+	postProcessOptions(opts)
+	return opts
+}
+
+// ReadColorConfig reads saved color configs if available
+func ReadColorConfig(opts *Options) {
 	// Get environment variable: FZF_PATH (This should be registered manually by user)
 	fzfPath := os.Getenv("FZF_PATH")
 	if len(fzfPath) > 0 {
@@ -1331,10 +1331,4 @@ func ParseOptions() *Options {
 			parseOptions(opts, words[:len(words) - 1])
 		}
 	} 
-
-	// Options from command-line arguments
-	parseOptions(opts, os.Args[1:])
-
-	postProcessOptions(opts)
-	return opts
 }

--- a/fzf/src/options.go
+++ b/fzf/src/options.go
@@ -1021,7 +1021,8 @@ func parseOptions(opts *Options, allArgs []string) {
 				opts.Theme = tui.EmptyTheme()
 			} else if spec == "g" {
 				initWindow()
-				configFile, err := os.Open(".ColorConfig")
+				fzfPath := os.Getenv("FZF_PATH")
+				configFile, err := os.Open(fzfPath + ".ColorConfig")
 				if err == nil {
 					data := make([]byte, 200)
 					configFile.Read(data)
@@ -1313,8 +1314,9 @@ func ParseOptions() *Options {
 	if len(words) > 0 {
 		parseOptions(opts, words)
 	}
-
-	configFile, err := os.Open(".ColorConfig")
+	// Get environment variable: FZF_PATH (This should be registered manually by user)
+	fzfPath := os.Getenv("FZF_PATH")
+	configFile, err := os.Open(fzfPath + ".ColorConfig")
 	if err == nil {
 		data := make([]byte, 200)
 		configFile.Read(data)

--- a/fzf/src/options.go
+++ b/fzf/src/options.go
@@ -1022,6 +1022,9 @@ func parseOptions(opts *Options, allArgs []string) {
 			} else if spec == "g" {
 				initWindow()
 				fzfPath := os.Getenv("FZF_PATH")
+				if len(fzfPath) > 0 {
+					fzfPath = fzfPath + "/"
+				}
 				configFile, err := os.Open(fzfPath + ".ColorConfig")
 				if err == nil {
 					data := make([]byte, 200)
@@ -1316,6 +1319,9 @@ func ParseOptions() *Options {
 	}
 	// Get environment variable: FZF_PATH (This should be registered manually by user)
 	fzfPath := os.Getenv("FZF_PATH")
+	if len(fzfPath) > 0 {
+		fzfPath = fzfPath + "/"
+	}
 	configFile, err := os.Open(fzfPath + ".ColorConfig")
 	if err == nil {
 		data := make([]byte, 200)


### PR DESCRIPTION
FZF_PATH 환경변수를 등록하면 어디서 fzf를 실행시키든 설정한 color theme가 적용되도록 함

echo FZF_PATH="path/to/fzf"
echo PATH=$FZF_PATH:$PATH

.ColorConfig 파일을 읽는 code snippet이 중복되어서 ReadColorConfig() 함수로 분리하였음 (options.go)